### PR TITLE
Android build environment has dropped GCC in favour of CLang.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'org.ajoberstar:grgit:1.1.0'
     }
 }
@@ -21,8 +21,8 @@ allprojects {
     project.ext {
         minSdkVersion=22
         compileSdkVersion=27
-        targetSdkVersion=27
-        buildToolsVersion='27.0.1'
+        targetSdkVersion=24
+        buildToolsVersion='27.0.3'
         exoPlayerVersion='2.6.1'
         supportVersion='27.0.2'
         glideVersion='4.4.0'

--- a/extensions/ffmpeg/build.gradle
+++ b/extensions/ffmpeg/build.gradle
@@ -15,7 +15,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion
@@ -30,7 +29,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments "-DANDROID_PLATFORM=android-21", "-DANDROID_TOOLCHAIN=gcc", "-DANDROID_STL=gnustl_static"
+                arguments "-DANDROID_PLATFORM=android-21", "-DANDROID_STL=c++_static"
             }
         }
     }
@@ -46,7 +45,6 @@ android {
         }
     }
 
-    buildToolsVersion "${project.ext.buildToolsVersion}"
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Oct 29 09:18:10 CET 2017
+#Wed Jun 19 12:38:21 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/msgexchange/build.gradle
+++ b/msgexchange/build.gradle
@@ -2,8 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
-    
+
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
@@ -20,7 +19,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments "-DANDROID_PLATFORM=android-21", "-DANDROID_TOOLCHAIN=gcc", "-DANDROID_STL=gnustl_static"
+                arguments "-DANDROID_PLATFORM=android-21", "-DANDROID_STL=c++_static"
             }
         }
     }

--- a/robotv-atv/build.gradle
+++ b/robotv-atv/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     signingConfigs {
         release {
@@ -34,7 +33,6 @@ android {
         }
     }
 
-    buildToolsVersion "${project.ext.buildToolsVersion}"
 }
 
 dependencies {

--- a/robotv-client/build.gradle
+++ b/robotv-client/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion

--- a/robotv-player/build.gradle
+++ b/robotv-player/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion


### PR DESCRIPTION
Gradle minimum supported version is 5.1.1.